### PR TITLE
Add method to skip writing the current indent

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -42,6 +42,12 @@ impl<'i, W: fmt::Write> IndentWriter<'i, W> {
         }
     }
 
+    /// If we're currently at the start of a line and would write indentation,
+    /// don't, skip this one and wait until the next one.
+    pub fn skip_next_indent(&mut self) {
+        self.need_indent = false;
+    }
+
     /// Extract the writer from the `IndentWriter`, discarding any in-progress
     /// indent state.
     pub fn into_inner(self) -> W {

--- a/src/io.rs
+++ b/src/io.rs
@@ -61,6 +61,14 @@ impl<'i, W: io::Write> IndentWriter<'i, W> {
         }
     }
 
+    /// If we're currently at the start of a line and would write indentation,
+    /// don't, skip this one and wait until the next one.
+    pub fn skip_next_indent(&mut self) {
+        if let NeedIndent = self.state {
+            self.state = MidLine;
+        }
+    }
+
     /// Extract the writer from the `IndentWriter`, discarding any in-progress
     /// indent state.
     pub fn into_inner(self) -> W {

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -88,6 +88,28 @@ fn test_multi_indent() {
     )
 }
 
+#[test]
+fn test_skip_next() {
+    let mut dest = String::new();
+
+    writeln!(dest, "😀 😀 😀").unwrap();
+    let mut indent = IndentWriter::new("\t", &mut dest);
+    indent.skip_next_indent();
+    writeln!(indent, "😀 😀 😀").unwrap();
+    writeln!(indent, "😀 😀 😀").unwrap();
+    indent.skip_next_indent();
+    writeln!(indent, "😀 😀 😀").unwrap();
+
+    assert_eq!(
+        dest,
+        "😀 😀 😀
+😀 😀 😀
+\t😀 😀 😀
+😀 😀 😀
+"
+    )
+}
+
 // Technically this doesn't test anything in the crate, it just ensures that OneByteAtATime works
 #[test]
 fn test_partial_writes() {

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -94,6 +94,29 @@ fn test_multi_indent() {
     )
 }
 
+#[test]
+fn test_skip_next() {
+    let mut dest = Vec::new();
+
+    writeln!(dest, "😀 😀 😀").unwrap();
+    let mut indent = IndentWriter::new("\t", &mut dest);
+    indent.skip_next_indent();
+    writeln!(indent, "😀 😀 😀").unwrap();
+    writeln!(indent, "😀 😀 😀").unwrap();
+    indent.skip_next_indent();
+    writeln!(indent, "😀 😀 😀").unwrap();
+
+    let result = from_utf8(&dest).expect("Wrote invalid utf8 to dest");
+    assert_eq!(
+        result,
+        "😀 😀 😀
+😀 😀 😀
+\t😀 😀 😀
+😀 😀 😀
+"
+    )
+}
+
 // Technically this doesn't test anything in the crate, it just ensures that OneByteAtATime works
 #[test]
 fn test_partial_writes() {


### PR DESCRIPTION
A different approach than what I mentioned in #3, that would allow skipping other indents than just the first. I'm not sure what's the best design, happy to change it if you can think of something better.

fixes #3