### PR TITLE
Update the io::IndentWriter to allow you to increase and decrease the level of indentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indent_write"
-version = "2.2.0"
+version = "3.0.0"
 authors = ["Nathan West <Lucretiel@gmail.com>"]
 edition = "2018"
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -22,7 +22,12 @@ use IndentState::*;
 /// each non-empty line. Specifically, this means it will insert an indent
 /// between each newline when followed by a non-newline.
 ///
-/// These writers can be nested to provide increasing levels of indentation.
+/// An `IndentWriter` has an [`Self::indent_level`] which starts at 0, meaning
+/// no indentation will be written. Call [`Self::inc()`] and [`Self::dec()`] to
+/// increase and decrease the amount of indentation.
+///
+/// If you want to use differing indentation strings, say a mixture of tabs and
+/// spaces, then you can nest writers.
 ///
 /// # Example
 ///
@@ -33,6 +38,7 @@ use IndentState::*;
 /// let output = Vec::new();
 ///
 /// let mut indented = IndentWriter::new("\t", output);
+/// indented.inc();
 ///
 /// // Lines will be indented
 /// write!(indented, "Line 1\nLine 2\n");
@@ -55,7 +61,8 @@ pub struct IndentWriter<'i, W> {
 }
 
 impl<'i, W: io::Write> IndentWriter<'i, W> {
-    /// Create a new [`IndentWriter`] with a [`Self::indent_level()`] of 0.
+    /// Create a new [`IndentWriter`] with a [`Self::indent_level()`] of 0
+    /// and `indent` to be used to create the indentation.
     pub fn new(indent: &'i str, writer: W) -> Self {
         Self {
             writer,

--- a/src/io.rs
+++ b/src/io.rs
@@ -153,7 +153,6 @@ impl<W: io::Write> io::Write for IndentWriter<W> {
                     // We are at the beginning of a non-empty line presently.
                     // Begin inserting an indent now, then continue looping
                     // (since we haven't yet attempted to write user data)
-                    //Some(0) => self.state = WritingIndent(self.required_indent.clone()),
                     Some(0) => self.state = WritingIndent(0..self.required_indent.len()),
 
                     // There's an upcoming non-empty line. Write out the

--- a/src/io.rs
+++ b/src/io.rs
@@ -51,9 +51,9 @@ use IndentState::*;
 /// assert_eq!(indented.get_ref(), b"\tLine 1\n\tLine 2\n\n\n\tLine 3\n\n");
 /// ```
 #[derive(Debug, Clone)]
-pub struct IndentWriter<'i, W> {
+pub struct IndentWriter<W> {
     writer: W,
-    indent: &'i str,
+    indent: String,
     indent_level: u16,
     // The `required_indent` is the `indent` repeated `indent_level` times.
     // We recalculate it when `indent_level` changes. It gets cloned into
@@ -62,13 +62,13 @@ pub struct IndentWriter<'i, W> {
     state: IndentState,
 }
 
-impl<'i, W: io::Write> IndentWriter<'i, W> {
+impl<W: io::Write> IndentWriter<W> {
     /// Create a new [`IndentWriter`] with a [`Self::indent_level()`] of 0
     /// and `indent` to be used to create the indentation.
-    pub fn new(indent: &'i str, writer: W) -> Self {
+    pub fn new<S: Into<String>>(indent: S, writer: W) -> Self {
         Self {
             writer,
-            indent,
+            indent: indent.into(),
             indent_level: 0,
             required_indent: Vec::new(),
             state: NeedIndent,
@@ -112,12 +112,12 @@ impl<'i, W: io::Write> IndentWriter<'i, W> {
 
     /// Get the string being used as an indent for each line
     #[inline]
-    pub fn indent(&self) -> &'i str {
-        self.indent
+    pub fn indent(&self) -> &str {
+        &self.indent
     }
 }
 
-impl<'i, W: io::Write> io::Write for IndentWriter<'i, W> {
+impl<W: io::Write> io::Write for IndentWriter<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         loop {
             match self.state {

--- a/src/io.rs
+++ b/src/io.rs
@@ -25,8 +25,8 @@ use IndentState::*;
 /// between each newline when followed by a non-newline.
 ///
 /// An `IndentWriter` has an [`Self::indent_level`] which starts at 0, meaning
-/// no indentation will be written. Call [`Self::inc()`] and [`Self::dec()`] to
-/// increase and decrease the amount of indentation.
+/// no indentation will be written. Call [`Self::indent()`] and
+/// [`Self::outdent()`] to increase and decrease the amount of indentation.
 ///
 /// If you want to use differing indentation strings, say a mixture of tabs and
 /// spaces, then you can nest writers.

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,7 +1,5 @@
 use std::io;
 
-use super::Inspect;
-
 #[derive(Debug, Copy, Clone)]
 enum IndentState<'a> {
     // We are currently writing a line. Forward writes until the end of the
@@ -183,7 +181,7 @@ impl<'i, W: io::Write> io::Write for IndentWriter<'i, W> {
     fn flush(&mut self) -> io::Result<()> {
         // If we're currently in the middle of writing an indent, flush it
         while let WritingIndent(ref mut indent) = self.state {
-            match self.writer.write(*indent)? {
+            match self.writer.write(indent)? {
                 // We wrote the entire indent. Proceed with the flush
                 len if len >= indent.len() => self.state = MidLine,
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -56,8 +56,7 @@ pub struct IndentWriter<W> {
     indent: String,
     indent_level: u16,
     // The `required_indent` is the `indent` repeated `indent_level` times.
-    // We recalculate it when `indent_level` changes. It gets cloned into
-    // `state` whenever we need to write an indent.
+    // We recalculate it when `indent_level` changes.
     required_indent: Vec<u8>,
     state: IndentState,
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -57,16 +57,13 @@ pub struct IndentWriter<'i, W> {
 impl<'i, W: io::Write> IndentWriter<'i, W> {
     /// Create a new [`IndentWriter`] with a [`Self::indent_level()`] of 0.
     pub fn new(indent: &'i str, writer: W) -> Self {
-        let mut s = Self {
+        Self {
             writer,
             indent,
             indent_level: 0,
             required_indent: Vec::new(),
             state: NeedIndent,
-        };
-
-        s.inc();
-        s
+        }
     }
 
     /// Increments the [`Self::indent_level()`] by 1.

--- a/src/io.rs
+++ b/src/io.rs
@@ -57,13 +57,16 @@ pub struct IndentWriter<'i, W> {
 impl<'i, W: io::Write> IndentWriter<'i, W> {
     /// Create a new [`IndentWriter`] with a [`Self::indent_level()`] of 0.
     pub fn new(indent: &'i str, writer: W) -> Self {
-        Self {
+        let mut s = Self {
             writer,
             indent,
             indent_level: 0,
             required_indent: Vec::new(),
             state: NeedIndent,
-        }
+        };
+
+        s.inc();
+        s
     }
 
     /// Increments the [`Self::indent_level()`] by 1.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,29 +13,3 @@ pub mod indentable;
 
 #[cfg(feature = "std")]
 pub mod io;
-
-trait Inspect<T> {
-    fn inspect(self, func: impl FnOnce(&T)) -> Self;
-}
-
-impl<T> Inspect<T> for Option<T> {
-    #[inline]
-    fn inspect(self, func: impl FnOnce(&T)) -> Self {
-        if let Some(ref value) = self {
-            func(value)
-        }
-
-        self
-    }
-}
-
-impl<T, E> Inspect<T> for Result<T, E> {
-    #[inline]
-    fn inspect(self, func: impl FnOnce(&T)) -> Self {
-        if let Ok(ref value) = self {
-            func(value)
-        }
-
-        self
-    }
-}

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -31,7 +31,7 @@ fn basic_test() {
 
     {
         let mut writer = IndentWriter::new("\t", &mut dest);
-        writer.inc();
+        writer.indent();
         for line in CONTENT {
             writeln!(writer, "{}", line).unwrap();
         }
@@ -45,7 +45,7 @@ fn basic_test() {
 fn test_prefix() {
     let mut dest = Vec::new();
     let mut writer = IndentWriter::new("    ", &mut dest);
-    writer.inc();
+    writer.indent();
 
     for line in CONTENT {
         write!(writer, "{}\n", line).unwrap();
@@ -62,25 +62,25 @@ fn test_inc_and_dec() {
 
     writeln!(writer, "<trk>").unwrap();
 
-    writer.inc();
+    writer.indent();
     writeln!(writer, "<name>Lincs Riding</name>").unwrap();
     writeln!(writer, "<trkseg>").unwrap();
 
-    writer.inc();
+    writer.indent();
     writeln!(writer, "<trkpt lat=\"53.246708\" lon=\"-0.801052\">").unwrap();
 
-    writer.inc();
+    writer.indent();
     writeln!(writer, "<ele>16.4</ele>").unwrap();
     writeln!(writer, "<time>2024-01-02T10:52:25Z</time>").unwrap();
 
-    writer.dec();
+    writer.outdent();
     writeln!(writer, "</trkpt>").unwrap();
 
-    writer.dec();
+    writer.outdent();
     writeln!(writer, "</trkseg>").unwrap();
     writeln!(writer, "<extensions>\n    <hr>130</hr>\n</extensions>").unwrap();
 
-    writer.dec();
+    writer.outdent();
     writeln!(writer, "</trk>").unwrap();
 
     let result = from_utf8(&dest).expect("Wrote invalid utf8 to dest");
@@ -106,7 +106,7 @@ fn test_inc_and_dec() {
 fn test_reset() {
     let mut dest = Vec::new();
     let mut writer = IndentWriter::new("    ", &mut dest);
-    writer.inc();
+    writer.indent();
 
     writeln!(writer, "FIRST").unwrap();
     writer.reset();
@@ -122,15 +122,15 @@ fn test_multi_indent() {
     writeln!(dest, "{}", "😀 😀 😀").unwrap();
     {
         let mut indent1 = IndentWriter::new("\t", &mut dest);
-        indent1.inc();
+        indent1.indent();
         writeln!(indent1, "{}", "😀 😀 😀").unwrap();
         {
             let mut indent2 = IndentWriter::new("\t", &mut indent1);
-            indent2.inc();
+            indent2.indent();
             writeln!(indent2, "{}", "😀 😀 😀").unwrap();
             {
                 let mut indent3 = IndentWriter::new("\t", &mut indent2);
-                indent3.inc();
+                indent3.indent();
                 writeln!(indent3, "{}", "😀 😀 😀").unwrap();
                 writeln!(indent3, "").unwrap();
             }
@@ -169,7 +169,7 @@ fn test_partial_simple_indent_writes() {
     {
         let writer = OneByteAtATime(&mut dest);
         let mut writer = IndentWriter::new("\t", writer);
-        writer.inc();
+        writer.indent();
         write!(writer, "{}\n", "Hello, World").unwrap();
         write!(writer, "{}\n", "😀 😀 😀\n😀 😀 😀").unwrap();
     }
@@ -184,7 +184,7 @@ fn test_partial_simple_indent_writes_inverted() {
     let mut dest = Vec::new();
     {
         let mut writer = IndentWriter::new("\t", &mut dest);
-        writer.inc();
+        writer.indent();
         let mut writer = OneByteAtATime(writer);
         write!(writer, "{}\n", "Hello, World").unwrap();
         write!(writer, "{}\n", "😀 😀 😀\n😀 😀 😀").unwrap();
@@ -201,7 +201,7 @@ fn test_partial_writes_combined() {
     {
         let writer = OneByteAtATime(&mut dest);
         let mut writer = IndentWriter::new("    ", writer);
-        writer.inc();
+        writer.indent();
         let mut writer = OneByteAtATime(writer);
 
         write!(writer, "{}\n", "Hello, World").unwrap();
@@ -222,13 +222,13 @@ fn test_writes_with_multibyte_unicode() {
     let mut writer = IndentWriter::new("🌊ḈΣ ", writer);
 
     writeln!(writer, "<point>").unwrap();
-    writer.inc();
+    writer.indent();
     writeln!(writer, "<lat>12.3</lat>").unwrap();
-    writer.inc();
+    writer.indent();
     writeln!(writer, "<desc>Description</desc>").unwrap();
-    writer.dec();
+    writer.outdent();
     writeln!(writer, "<lon>182.3</lon>").unwrap();
-    writer.dec();
+    writer.outdent();
     writeln!(writer, "</point>").unwrap();
 
     let result = String::from_utf8(dest).expect("Wrote invalid utf8 to dest");

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -25,24 +25,6 @@ impl<W: Write> Write for OneByteAtATime<W> {
 
 const CONTENT: &'static [&'static str] = &["\t😀 😀 😀", "\t\t😀 😀 😀", "\t😀 😀 😀"];
 
-// Using a function to wrap a writer, run a standard test and check against expected
-macro_rules! test_harness {
-    ($target:ident => $transform:expr, expect: $result:expr) => {{
-        let mut dest = Vec::new();
-
-        {
-            let $target = &mut dest;
-            let mut indented_dest = $transform;
-            for line in CONTENT {
-                write!(&mut indented_dest, "{}\n", line).unwrap();
-            }
-        }
-
-        let result = from_utf8(&dest).expect("Wrote invalid utf8 to dest");
-        assert_eq!(result, $result);
-    }};
-}
-
 #[test]
 fn basic_test() {
     let mut dest = Vec::new();
@@ -61,7 +43,16 @@ fn basic_test() {
 
 #[test]
 fn test_prefix() {
-    test_harness!(w => IndentWriter::new("    ", w), expect: "    \t😀 😀 😀\n    \t\t😀 😀 😀\n    \t😀 😀 😀\n")
+    let mut dest = Vec::new();
+    let mut writer = IndentWriter::new("    ", &mut dest);
+    writer.inc();
+
+    for line in CONTENT {
+        write!(writer, "{}\n", line).unwrap();
+    }
+
+    let result = from_utf8(&dest).expect("Wrote invalid utf8 to dest");
+    assert_eq!(result, "    \t😀 😀 😀\n    \t\t😀 😀 😀\n    \t😀 😀 😀\n");
 }
 
 #[test]

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -61,15 +61,15 @@ fn test_inc_and_dec() {
     let mut writer = IndentWriter::new("    ", &mut dest);
 
     writeln!(writer, "<trk>").unwrap();
-    writer.inc();
 
+    writer.inc();
     writeln!(writer, "<name>Lincs Riding</name>").unwrap();
     writeln!(writer, "<trkseg>").unwrap();
-    writer.inc();
 
+    writer.inc();
     writeln!(writer, "<trkpt lat=\"53.246708\" lon=\"-0.801052\">").unwrap();
-    writer.inc();
 
+    writer.inc();
     writeln!(writer, "<ele>16.4</ele>").unwrap();
     writeln!(writer, "<time>2024-01-02T10:52:25Z</time>").unwrap();
 
@@ -78,7 +78,6 @@ fn test_inc_and_dec() {
 
     writer.dec();
     writeln!(writer, "</trkseg>").unwrap();
-
     writeln!(writer, "<extensions>\n    <hr>130</hr>\n</extensions>").unwrap();
 
     writer.dec();
@@ -101,6 +100,20 @@ fn test_inc_and_dec() {
 </trk>
 "
     );
+}
+
+#[test]
+fn test_reset() {
+    let mut dest = Vec::new();
+    let mut writer = IndentWriter::new("    ", &mut dest);
+    writer.inc();
+
+    writeln!(writer, "FIRST").unwrap();
+    writer.reset();
+    writeln!(writer, "SECOND").unwrap();
+
+    let result = from_utf8(&dest).expect("Wrote invalid utf8 to dest");
+    assert_eq!(result, "    FIRST\nSECOND\n");
 }
 
 #[test]

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -56,6 +56,54 @@ fn test_prefix() {
 }
 
 #[test]
+fn test_inc_and_dec() {
+    let mut dest = Vec::new();
+    let mut writer = IndentWriter::new("    ", &mut dest);
+
+    writeln!(writer, "<trk>").unwrap();
+    writer.inc();
+
+    writeln!(writer, "<name>Lincs Riding</name>").unwrap();
+    writeln!(writer, "<trkseg>").unwrap();
+    writer.inc();
+
+    writeln!(writer, "<trkpt lat=\"53.246708\" lon=\"-0.801052\">").unwrap();
+    writer.inc();
+
+    writeln!(writer, "<ele>16.4</ele>").unwrap();
+    writeln!(writer, "<time>2024-01-02T10:52:25Z</time>").unwrap();
+
+    writer.dec();
+    writeln!(writer, "</trkpt>").unwrap();
+
+    writer.dec();
+    writeln!(writer, "</trkseg>").unwrap();
+
+    writeln!(writer, "<extensions>\n    <hr>130</hr>\n</extensions>").unwrap();
+
+    writer.dec();
+    writeln!(writer, "</trk>").unwrap();
+
+    let result = from_utf8(&dest).expect("Wrote invalid utf8 to dest");
+    assert_eq!(
+        result,
+        "<trk>
+    <name>Lincs Riding</name>
+    <trkseg>
+        <trkpt lat=\"53.246708\" lon=\"-0.801052\">
+            <ele>16.4</ele>
+            <time>2024-01-02T10:52:25Z</time>
+        </trkpt>
+    </trkseg>
+    <extensions>
+        <hr>130</hr>
+    </extensions>
+</trk>
+"
+    );
+}
+
+#[test]
 fn test_multi_indent() {
     let mut dest = Vec::new();
     writeln!(dest, "{}", "😀 😀 😀").unwrap();

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -212,3 +212,33 @@ fn test_partial_writes_combined() {
         Ok("    Hello, World\n    😀 😀 😀\n    😀 😀 😀\n")
     );
 }
+
+#[test]
+fn test_writes_with_multibyte_unicode() {
+    let mut dest = Vec::new();
+    let writer = OneByteAtATime(&mut dest);
+    // 4, 3, 2 and 1 byte characters. This tests that our logic in inc()
+    // and dec() is correct, and the range slicing in write() is corretc.
+    let mut writer = IndentWriter::new("🌊ḈΣ ", writer);
+
+    writeln!(writer, "<point>").unwrap();
+    writer.inc();
+    writeln!(writer, "<lat>12.3</lat>").unwrap();
+    writer.inc();
+    writeln!(writer, "<desc>Description</desc>").unwrap();
+    writer.dec();
+    writeln!(writer, "<lon>182.3</lon>").unwrap();
+    writer.dec();
+    writeln!(writer, "</point>").unwrap();
+
+    let result = String::from_utf8(dest).expect("Wrote invalid utf8 to dest");
+    assert_eq!(
+        result,
+        "<point>
+🌊ḈΣ <lat>12.3</lat>
+🌊ḈΣ 🌊ḈΣ <desc>Description</desc>
+🌊ḈΣ <lon>182.3</lon>
+</point>
+"
+    );
+}

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -49,6 +49,7 @@ fn basic_test() {
 
     {
         let mut writer = IndentWriter::new("\t", &mut dest);
+        writer.inc();
         for line in CONTENT {
             writeln!(writer, "{}", line).unwrap();
         }
@@ -69,12 +70,15 @@ fn test_multi_indent() {
     writeln!(dest, "{}", "😀 😀 😀").unwrap();
     {
         let mut indent1 = IndentWriter::new("\t", &mut dest);
+        indent1.inc();
         writeln!(indent1, "{}", "😀 😀 😀").unwrap();
         {
             let mut indent2 = IndentWriter::new("\t", &mut indent1);
+            indent2.inc();
             writeln!(indent2, "{}", "😀 😀 😀").unwrap();
             {
                 let mut indent3 = IndentWriter::new("\t", &mut indent2);
+                indent3.inc();
                 writeln!(indent3, "{}", "😀 😀 😀").unwrap();
                 writeln!(indent3, "").unwrap();
             }
@@ -113,6 +117,7 @@ fn test_partial_simple_indent_writes() {
     {
         let writer = OneByteAtATime(&mut dest);
         let mut writer = IndentWriter::new("\t", writer);
+        writer.inc();
         write!(writer, "{}\n", "Hello, World").unwrap();
         write!(writer, "{}\n", "😀 😀 😀\n😀 😀 😀").unwrap();
     }
@@ -126,7 +131,8 @@ fn test_partial_simple_indent_writes() {
 fn test_partial_simple_indent_writes_inverted() {
     let mut dest = Vec::new();
     {
-        let writer = IndentWriter::new("\t", &mut dest);
+        let mut writer = IndentWriter::new("\t", &mut dest);
+        writer.inc();
         let mut writer = OneByteAtATime(writer);
         write!(writer, "{}\n", "Hello, World").unwrap();
         write!(writer, "{}\n", "😀 😀 😀\n😀 😀 😀").unwrap();
@@ -142,7 +148,8 @@ fn test_partial_writes_combined() {
     let mut dest = Vec::new();
     {
         let writer = OneByteAtATime(&mut dest);
-        let writer = IndentWriter::new("    ", writer);
+        let mut writer = IndentWriter::new("    ", writer);
+        writer.inc();
         let mut writer = OneByteAtATime(writer);
 
         write!(writer, "{}\n", "Hello, World").unwrap();


### PR DESCRIPTION
Hi,

I needed an indenting writer to help me generate nicely formatted XML. I came across your lib, but when needing to indent at several levels I found the wrapping of writers in writers a bit unergonomic. So I changed the writer to have a concept of `indent_level` (0..n) which controls how many times the `indent` string (now renamed as `base_indent`) is written before the line of text.

`indent` and `outdent` methods allow you to increment and decrement the amount of indentation (I had to rename your `indent` method to allow that change, which I was a bit unhappy about as it makes upgrading from v2 a slight footgun but it feels the right way to go). Initially I had those methods called `inc` and `dec`, which are poorer names in my opinion.

Other changes including getting rid of the lifetime parameters in favour of owning the `base_indent` as a String and removing the `skip_initial` constructor (because it seemed a bit special-cased and is completely unnecessary now, just don't call `indent` before the first write if you want that behaviour).

I didn't make any changes to the other two classes in the `fmt` and `indentable` modules, I don't quite follow what the use-case is for them to be honest so I left alone.

Semver bumped to 3.0.0 due to API changes.